### PR TITLE
Finish Admin Orders Card

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,14 @@
 class Admin::DashboardController < Admin::BaseController
 
   def index
+    @orders_by_status = Order.all.group(:status).count
+    @statuses = Order.statuses
 
+    if params[:status]
+      @orders = Order.where("status = #{params[:status]}")
+    else
+      @orders = Order.all
+    end
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,10 @@
+class OrdersController < ApplicationController
+  def update
+    @order = Order.find(params[:id])
+    if params[:status] && current_admin?
+      @order.update(status: params[:status])
+      redirect_to admin_dashboard_path
+    end
+  end
+
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -4,5 +4,6 @@ class Order < ApplicationRecord
   has_many :order_items
   has_many :items, through: :order_items
 
+  enum status: %w(Ordered Paid Completed Cancelled)
   enum state: %w(AL AK AZ AR CA CO CT DE FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY)
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,6 +1,44 @@
 <h1>Admin Dashboard</h1>
-
+<h4> <%= link_to "Edit Profile", edit_user_path(current_user) %></h4>
 <%= link_to "View Your Items", admin_items_path %>
 
+<h3>Orders by Status</h3>
+<table>
+  <th>Status</th>
+  <th>Count of Orders</th>
+  <% @orders_by_status.each do |status, count| %>
+  <tr>
+    <td><%= status %></td>
+    <td><%= count %></td>
+  </tr>
+  <% end %>
+</table>
 
-<h1> <%= link_to "Edit Profile", edit_user_path(current_user) %></h1>
+<h3>Orders</h3>
+<%= form_tag admin_dashboard_path, method: :get do %>
+  <%= label_tag "Filter" %>
+  <%= select_tag :status, options_for_select(@statuses, params[:status]) %>
+  <%= submit_tag "Apply" %>
+<% end %>
+<table class="all-orders">
+  <th>Order ID</th>
+  <th>Status</th>
+  <th></th>
+  <th></th>
+  <% @orders.each do |order| %>
+  <tr id=<%= order.id %>>
+      <td><%= link_to order.id, order_path(order) %></td>
+      <td><%= order.status %></td>
+    <% if order.status == "Ordered" %>
+      <td><%= button_to "mark as paid", order_path(order, status: "Paid"), method: :put%></td>
+      <td><%= button_to "cancel", order_path(order, status: "Cancelled"), method: :put %></td>
+    <% elsif order.status == "Paid" %>
+      <td><%= button_to "mark as completed", order_path(order, status: "Completed"), method: :put%>%></td>
+      <td><%= button_to "cancel", order_path(order, status: "Cancelled"), method: :put %> %></td>
+    <% else %>
+      <td></td>
+      <td></td>
+    <% end %>
+  </tr>
+  <% end %>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
   resources :items, only: [:index, :show]
 
+  resources :orders, only: [:show, :edit, :update]
+
   namespace :admin do
     get 'dashboard', to: "dashboard#index"
     resources :items

--- a/db/migrate/20180106204813_add_full_name_to_order.rb
+++ b/db/migrate/20180106204813_add_full_name_to_order.rb
@@ -1,0 +1,5 @@
+class AddFullNameToOrder < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders, :full_name, :string
+  end
+end

--- a/db/migrate/20180106204813_add_full_name_to_order.rb
+++ b/db/migrate/20180106204813_add_full_name_to_order.rb
@@ -1,5 +1,0 @@
-class AddFullNameToOrder < ActiveRecord::Migration[5.1]
-  def change
-    add_column :orders, :full_name, :string
-  end
-end

--- a/db/migrate/20180106223612_remove_columns_from_orders.rb
+++ b/db/migrate/20180106223612_remove_columns_from_orders.rb
@@ -1,0 +1,8 @@
+class RemoveColumnsFromOrders < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :orders, :street
+    remove_column :orders, :city
+    remove_column :orders, :state
+    remove_column :orders, :zipcode
+  end
+end

--- a/db/migrate/20180106223800_add_column_to_user.rb
+++ b/db/migrate/20180106223800_add_column_to_user.rb
@@ -1,0 +1,9 @@
+class AddColumnToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :full_name, :string
+    add_column :users, :street, :string
+    add_column :users, :city, :string
+    add_column :users, :state, :string
+    add_column :users, :zipcode, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106180845) do
+ActiveRecord::Schema.define(version: 20180106223800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,12 +41,9 @@ ActiveRecord::Schema.define(version: 20180106180845) do
   create_table "orders", force: :cascade do |t|
     t.integer "status"
     t.bigint "user_id"
-    t.string "street"
-    t.string "city"
-    t.integer "state"
-    t.integer "zipcode"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "full_name"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -54,6 +51,11 @@ ActiveRecord::Schema.define(version: 20180106180845) do
     t.string "username"
     t.string "password_digest"
     t.integer "role", default: 0
+    t.string "full_name"
+    t.string "street"
+    t.string "city"
+    t.string "state"
+    t.integer "zipcode"
   end
 
   add_foreign_key "order_items", "items"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,6 @@ ActiveRecord::Schema.define(version: 20180106223800) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "full_name"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180106180845) do
+ActiveRecord::Schema.define(version: 20180106204813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20180106180845) do
     t.integer "zipcode"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "full_name"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 

--- a/spec/factories/order_items.rb
+++ b/spec/factories/order_items.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :order_item do
+    association :order
+    association :item
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :order do
+    status 0
+    street "123 Main St"
+    city "Denver"
+    state 1
+    zipcode 80525
+    full_name "Max"
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,15 @@
 FactoryBot.define do
   factory :user do
-    username "bob"
+    sequence :username do |n|
+      "user #{n}"
+    end
     password "password"
     role 0
+  end
+
+  factory :admin, class: User do
+    username "admin"
+    password "password"
+    role 1
   end
 end

--- a/spec/features/admin/admin_can_view_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_view_dashboard_spec.rb
@@ -1,7 +1,7 @@
 describe "User tries to visit admin dashboard" do
   context "as admin" do
     it 'can see dashboard' do
-      user = User.create!(username: "Max", password: '12345', role:1)
+      User.create!(username: "Max", password: '12345', role:1)
 
       visit "/login"
 
@@ -15,6 +15,7 @@ describe "User tries to visit admin dashboard" do
       expect(page).to have_content("Logout")
     end
   end
+
   context "as default user" do
     it 'does not allow default user to see dashboard ' do
       user = create(:user)

--- a/spec/features/admin/admin_can_view_orders_on_dashboard_spec.rb
+++ b/spec/features/admin/admin_can_view_orders_on_dashboard_spec.rb
@@ -1,0 +1,146 @@
+describe "Admin can visit dashboard" do
+  describe "it sees a table with orders" do
+    before(:each) do
+      @ordered = create(:order)
+      @paid = create(:order, status: 1)
+      @cancelled = create(:order, status: 2)
+      @completed = create(:order, status: 3)
+      @admin = create(:admin)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+    end
+
+    it "sees all orders with a link to each order" do
+      visit admin_dashboard_path
+
+      expect(page).to have_content "Orders"
+      expect(page).to have_link @ordered.id
+      expect(page).to have_content @ordered.status
+      expect(page).to have_link @paid.id
+      expect(page).to have_content @paid.status
+      expect(page).to have_link @cancelled.id
+      expect(page).to have_content @cancelled.status
+      expect(page).to have_link @completed.id
+      expect(page).to have_content @completed.status
+    end
+
+    it "sees total number of each type of order" do
+      visit admin_dashboard_path
+
+      expect(page).to have_content "Orders by Status"
+      expect(page).to have_content "Ordered 1"
+      expect(page).to have_content "Paid 1"
+      expect(page).to have_content "Cancelled 1"
+      expect(page).to have_content "Completed 1"
+    end
+
+    it "it can filter orders by status type" do
+      visit admin_dashboard_path
+
+      select "Paid", from: "status"
+      click_on "Apply"
+
+      within ".all-orders" do
+        expect(page).to have_content ("Paid")
+        expect(page).to_not have_content ("Ordered")
+        expect(page).to_not have_content ("Cancelled")
+        expect(page).to_not have_content ("Completed")
+      end
+    end
+
+    describe "it sees buttons to transition between status types" do
+      context "status: Ordered" do
+        it "has button to cancel order and mark as paid" do
+          visit admin_dashboard_path
+
+          within "#1" do
+            expect(page).to have_button "mark as paid"
+            expect(page).to have_button "cancel"
+          end
+        end
+
+        it "can cancel order with cancel button" do
+          visit admin_dashboard_path
+
+          within "#1" do
+            click_button "cancel"
+          end
+
+          within "#1" do
+            expect(page).to have_content "Cancelled"
+            expect(page).to_not have_content "Ordered"
+          end
+        end
+
+        it "can mark as paid" do
+          visit admin_dashboard_path
+
+          within "#1" do
+            click_button "mark as paid"
+          end
+
+          within "#1" do
+            expect(page).to have_content "Paid"
+            expect(page).to_not have_content "Ordered"
+          end
+        end
+      end
+
+      context "status: Paid" do
+        it "has button to cancel order and mark as paid" do
+          visit admin_dashboard_path
+
+          within "#2" do
+            expect(page).to have_button "mark as complete"
+            expect(page).to have_button "cancel"
+          end
+        end
+
+        it "can cancel order with cancel button" do
+          visit admin_dashboard_path
+
+          within "#2" do
+            click_button "cancel"
+          end
+
+          within "#2" do
+            expect(page).to have_content "Cancelled"
+            expect(page).to_not have_content "Paid"
+          end
+        end
+
+        it "can mark as paid" do
+          visit admin_dashboard_path
+
+          within "#2" do
+            click_button "mark as complete"
+          end
+
+          within "#2" do
+            expect(page).to have_content "Complete"
+            expect(page).to_not have_content "Paid"
+          end
+        end
+      end
+
+      context "status: Cancelled" do
+        it "does not have button to cancel order" do
+          visit admin_dashboard_path
+
+          within "#3" do
+            expect(page).to_not have_button "cancel"
+          end
+        end
+      end
+
+      context "status: Completed" do
+        it "does not have button to cancel order" do
+          visit admin_dashboard_path
+
+          within "#4" do
+            expect(page).to_not have_button "cancel"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/users/user_can_sign_up_spec.rb
+++ b/spec/features/users/user_can_sign_up_spec.rb
@@ -27,7 +27,7 @@ describe User do
 
       click_on "Log In"
 
-      expect(current_path).to eq(user_path(user))
+      expect(current_path).to eq(dashboard_path)
 
       expect(page).to have_content("Logout")
     end


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Admin gets more info on their dashboard

* **What is the current behavior?** (You can also link to an open issue here)

Admin does not have order data on their dashboard

* **What is the new behavior (if this is a feature change)?**

As an Admin When I visit the dashboard Then I can see a listing of all orders And I can see the total number of orders for each status (“Ordered”, “Paid”, “Cancelled”, “Completed”) And I can see a link for each individual order And I can filter orders to display by each status type (“Ordered”, “Paid”, “Cancelled”, “Completed”) And I have links to transition between statuses
I can click on “cancel” on individual orders which are “paid” or “ordered”
I can click on “mark as paid” on orders that are “ordered”
I can click on “mark as completed” on orders that are “paid”



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
